### PR TITLE
Add linter tests

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,3 @@
+# Check code style with tflint
+tflint --loglevel=debug
+


### PR DESCRIPTION
Use ./run-tests.sh to execute test
Currently only does linter check with tflint
(tflint is expected to be found in PATH)

closes #10