### PR TITLE
Prefix project name with workspace name if not default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
-
+locals {
+  project_name = terraform.workspace == "default" ? var.project_name : "${terraform.workspace}${var.project_name}"
+}
 
 # module "tfstate_storage_azure" {
 #     source  = "./modules/tfstate_storage_azure"
@@ -13,13 +15,13 @@ module "k8s_cluster_azure" {
     source = "./modules/k8s"
     k8s_agent_count = var.k8s_agent_count
     k8s_resource_group_name_suffix = var.k8s_resource_group_name_suffix
-    project_name = var.project_name
+    project_name = local.project_name
 }
 
 module "container_registry_for_k8s" {
     source = "./modules/container_registry"
     container_registry_resource_group_suffix = var.container_registry_resource_group_suffix
-    project_name = var.project_name
+    project_name = local.project_name
     k8s_cluster_node_resource_group = module.k8s_cluster_azure.k8s_cluster_node_resource_group
     k8s_cluster_kubelet_managed_identity_id = module.k8s_cluster_azure.kubelet_object_id
 }


### PR DESCRIPTION
Previously, the project name had to be changed manually if one wanted to create separate instances of resource groups and resources. With this change, if Terraform workspace is something else than default, project name will be changed to "_${terraform.workspace}${var.project_name}_".

If you insist on using default TF workspace, you can still customize the project name via _variables.tf_.

closes #20 