### PR TITLE
Node count per tf workspace

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,7 @@
 locals {
   project_name = terraform.workspace == "default" ? var.project_name : "${terraform.workspace}${var.project_name}"
+  k8s_agent_count = terraform.workspace == "default" ? var.k8s_agent_count : 1
+
 }
 
 # module "tfstate_storage_azure" {


### PR DESCRIPTION
If workspace is `default` then deploy the amount of nodes specified in variables (default 3), else deploy 1 node.
This could be useful for testing purposes when you have to make changes quickly and test them. With this the deploy time is less than with the default node count. 

Further improvements:
* Instead of hard coding testing node, it could be specified in tfvars.