### PR TITLE
Node count per tf workspace

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   project_name = terraform.workspace == "default" ? var.project_name : "${terraform.workspace}${var.project_name}"
-  k8s_agent_count = terraform.workspace == "default" ? var.k8s_agent_count : 1
+  k8s_agent_count = terraform.workspace == "default" ? var.k8s_agent_count : var.testing_k8s_agent_count
 }
 
 # module "tfstate_storage_azure" {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
   project_name = terraform.workspace == "default" ? var.project_name : "${terraform.workspace}${var.project_name}"
+  k8s_agent_count = terraform.workspace == "default" ? var.k8s_agent_count : 1
 }
 
 # module "tfstate_storage_azure" {
@@ -13,7 +14,7 @@ locals {
 
 module "k8s_cluster_azure" {
     source = "./modules/k8s"
-    k8s_agent_count = var.k8s_agent_count
+    k8s_agent_count = local.k8s_agent_count
     k8s_resource_group_name_suffix = var.k8s_resource_group_name_suffix
     project_name = local.project_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,11 @@ variable "k8s_agent_count" {
     default = 3
 }
 
+# Specify node count for testing purposes
+variable "testing_k8s_agent_count" {
+    default = 1
+}
+
 # variable "k8s_ssh_public_key" {
 #     default = "~/.ssh/id_rsa.pub"
 # }


### PR DESCRIPTION
If workspace is default then deploy the amount of nodes specified in variables (default 3), else deploy 1 node.
This could be useful for testing purposes when you have to make changes quickly and test them. With this the deploy time is less than with the default node count.

Further improvements:

~~* Instead of hard coding other workspace's node amount, it could be specified in tfvars.~~
