### PR TITLE
Lock Hono Helm chart version number

### DIFF
--- a/modules/container_deployment/main.tf
+++ b/modules/container_deployment/main.tf
@@ -53,6 +53,7 @@ resource "helm_release" "hono" {
 
   repository = "https://eclipse.org/packages/charts"
   chart      = "hono"
+  version    = "1.5.9"
 
   set {
     name  = "prometheus.createInstance"


### PR DESCRIPTION
This commits locks version number of Hono Helm chart to 1.5.9.

Signed-off-by: Mikael Saarinen <mikael.saarinen@student.oulu.fi>