### PR TITLE
Switch mongodb deployment from Hono helm chart to Bitnami chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ override.tf.json
 # End of https://www.toptal.com/developers/gitignore/api/terraform
 
 *kubeconfig
+my_stuff.json

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -19,6 +19,24 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.0.2"
+  constraints = ">= 2.0.1"
+  hashes = [
+    "h1:NeS94WlOI85mRXQblK/s1oGO/pdz+2HCAsQp8ePQqH0=",
+    "zh:09f7b2389f0e41f51c933d014fe3a89aa53c12801ab45c082d3626689961d5a6",
+    "zh:0af792512adf59648b7cb7f0f194151ac926ae6805ffdb2baf61512b55933e17",
+    "zh:0e29837d65bf4dbe3b9766221a1a4448b2c9df7f4d3049a0b6812055e299c063",
+    "zh:25a0c4d1cba9a22f4d12f6465f191db6e2ec675cbc2c7751bf128bcae23848a8",
+    "zh:6d92f9ffd43a45f0f0da4c59cbb1790b163235882532a88344a53b8526808979",
+    "zh:7c98a0e05f106d4bbfc0c81f7d8b41bc8e867a99b30ccd472367d0414e778c30",
+    "zh:8de8232eedfa4ade990faea4ed3706f0846eb1d66fb82aa22718c7a9aeda92b1",
+    "zh:baff5ff10c9573104d25eece9f79477112ed6882c0ea9280ecbfa944d117838d",
+    "zh:d151fac8be471922cbe137f5a263f4854cdcfbf3fb8af7db83c709d64956934b",
+    "zh:e4d238facc27fc91d26aef79b7f398a6b9f3a1fe078c8d3f0cd4df47ec5aaacd",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version = "2.0.2"
   hashes = [

--- a/modules/container_deployment/.terraform.lock.hcl
+++ b/modules/container_deployment/.terraform.lock.hcl
@@ -19,9 +19,26 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.0.3"
+  hashes = [
+    "h1:eUr4dHyxlcLmLja0wBgJC7t5bfHzbtACyuumKPuDrGs=",
+    "zh:154e0aa489e474e2eeb3de94be7666133faf6fd950712a640425b2bf3a81ee95",
+    "zh:16a2be6c4b61d0c5205c63816148c7ab0c8f56a75c05e8d897fa4d5cac0c029a",
+    "zh:189e47bc723f8c29bcfe2c1638d43b8148f614ea86e642f4b50b2acb4b760224",
+    "zh:3763901d3630213002cb8c70bb24c628cd29738ff6591585250ea8636264abd6",
+    "zh:4822f85e4700ea049384523d98de0ef7d83549844b13e94bbd544cec05557a9a",
+    "zh:62c5b87b09e0051bab0b712e3ad465fd53e66f9619dbe76ee23519d1087d8a05",
+    "zh:a0a6a842b11190dd1841e98bbb74961074e7ffb95984be5cc392df9f532d803e",
+    "zh:beac4e6806e77447e1018f3404a5fbf782d20d82a0d9b4a31e9bfc7d2bbecab6",
+    "zh:e1bbaa09bf4f4a91ec7606f84d2e0200a02e7b24d045e8b5daebd87d7a75b7ce",
+    "zh:ed1e05c50212d4f57435ccdd68cfb98d8395927c316df76d1dd6509566d3aeaa",
+    "zh:fdc687e16a964bb652ddb670f6832fdead25235eca551796cfed70ec07d94931",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/kubernetes" {
-  version     = "2.0.2"
-  constraints = ">= 2.0.0"
+  version = "2.0.2"
   hashes = [
     "h1:PRfDnUFBD4ud7SgsMAa5S2Gd60FeriD1PWE6EifjXB0=",
     "zh:4e66d509c828b0a2e599a567ad470bf85ebada62788aead87a8fb621301dec55",

--- a/modules/container_deployment/main.tf
+++ b/modules/container_deployment/main.tf
@@ -3,27 +3,20 @@
 #https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/getting-started
 #https://www.hashicorp.com/blog/kubernetes-cluster-with-aks-and-terraform
 
-resource "kubernetes_namespace" "hono" {
-  metadata {
-    name = "hono"
-  }
-}
 
+
+# https://github.com/bitnami/azure-marketplace-charts/tree/master/bitnami/mongodb
 resource "helm_release" "mongodb" {
-  name = "mongodb"
+  name = "mongodb" 
 
   repository = "https://marketplace.azurecr.io/helm/v1/repo"
   chart      = "mongodb"
   version    = "~> 10.7.1"
+  cleanup_on_fail = "true"
+  values = [
+    file("${path.module}/mongo_values.yaml")
+  ]
 
-  set {
-    name  = "architecture"
-    value = "standalone"
-  }
-  set {
-    name  = "useStatefulSet"
-    value = "true"
-  }
   set_sensitive {
     name  = "auth.rootPassword"
     value = "root-secret"
@@ -33,34 +26,13 @@ resource "helm_release" "mongodb" {
     value = "hono-secret"
   }  
   set_sensitive {
-    name  = "auth.database"
-    value = "honodb"
-  }  
-  set_sensitive {
     name  = "auth.username"
     value = "honouser"
   }  
-  set {
-    name  = "replicaCount"
-    value = "2"
-  }  
-  set {
-    name  = "cleanup_on_fail"
-    value = "true"
-  }
-  # Uncomment these if you want the DB to be externally available. NB! Remember that this 
-  # script also has auth credentials, so use external access with caution.
-  # 
-  # set {
-  #   name  = "externalAccess.enabled"
-  #   value = "true"
-  # }
-  # set {
-  #   name  = "service.type"
-  #   value = "LoadBalancer"
-  # }
+
 }
 
+# https://github.com/eclipse/packages/tree/master/charts/hono
 resource "helm_release" "hono" {
   name = "hono"
 
@@ -118,44 +90,3 @@ resource "helm_release" "hono" {
     value = "true"
   }
 }
-
-/*
-resource "kubernetes_deployment" "test" {
-  metadata {
-    name = "test"
-    namespace= kubernetes_namespace.test.metadata.0.name
-  }
-  spec {
-    replicas = 2
-    selector {
-      match_labels = {
-        app = "test"
-      }
-    }
-    template {
-      metadata {
-        labels = {
-          app  = "test"
-        }
-      }
-      spec {
-        container {
-          image = "nginx:1.19.4"
-          name  = "nginx"
-
-          resources {
-            limits = {
-              memory = "512M"
-              cpu = "1"
-            }
-            requests = {
-              memory = "256M"
-              cpu = "50m"
-            }
-          }
-        }
-      }
-    }
-  }
-}
-*/

--- a/modules/container_deployment/mongo_values.yaml
+++ b/modules/container_deployment/mongo_values.yaml
@@ -1,0 +1,17 @@
+architecture: "standalone"
+persistence:
+  existingClaim: "mongodb-data"
+useStatefulSet: true
+metrics:
+  enabled: true
+replicaCount: 2
+auth:
+  database: "honodb"
+
+# Uncomment these if you want the DB to be externally available. NB! Remember that this 
+# script also has auth credentials, so use external access with caution.
+# 
+# externalAccess:
+#   enabled: true
+# service:
+#   type: "LoadBalancer"

--- a/modules/k8s/main.tf
+++ b/modules/k8s/main.tf
@@ -99,9 +99,30 @@ resource "kubernetes_storage_class" "azure-disk-retain" {
   }
   storage_provisioner = "kubernetes.io/azure-disk"
   reclaim_policy      = "Retain"
-  volume_binding_mode = "WaitForFirstConsumer"
+  volume_binding_mode = "Immediate"
   parameters = {
     kind        = "managed"
     cachingMode = "ReadOnly"
+  }
+}
+
+resource "kubernetes_persistent_volume_claim" "example" {
+  metadata {
+    name = "mongodb-data"
+  }
+  spec {
+    access_modes = ["ReadWriteOnce"]
+    resources {
+      requests = {
+        storage = "8Gi"
+      }
+    }
+    storage_class_name = "azure-disk-retain"
+  }
+}
+
+resource "kubernetes_namespace" "hono" {
+  metadata {
+    name = "hono"
   }
 }


### PR DESCRIPTION
Up to this point,  we have deployed MongoDB via Hono helm chart, which has quite limited (or difficult) configuration options. Commit e7167dbfa1b643ffc5db3c575eabe7622c912448 switches MongoDB deployment to use the [Bitnami MongoDB](https://github.com/bitnami/azure-marketplace-charts/tree/master/bitnami/mongodb) helm chart. 

Tested to be working, but currently has rather basic configuration.

Linked to #38, but the question of data persistence is still open.