### PR TITLE
Add Jaeger independent of Hono

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # .tfstate files
 *.tfstate
 *.tfstate.*
+.terraform.lock.hcl
 
 # Crash log files
 crash.log

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 # .tfstate files
 *.tfstate
 *.tfstate.*
-.terraform.lock.hcl
 
 # Crash log files
 crash.log

--- a/modules/container_deployment/hono_values.yaml
+++ b/modules/container_deployment/hono_values.yaml
@@ -1,7 +1,7 @@
 prometheus:
   createInstance: true
 jaegerBackendExample:
-  enabled: true
+  enabled: false
 grafana:
   enabled: true
 mongodb:

--- a/modules/container_deployment/main.tf
+++ b/modules/container_deployment/main.tf
@@ -54,3 +54,27 @@ resource "helm_release" "hono" {
     value = "hono-secret"
   }
 }
+
+resource "helm_release" "ingress-nginx" {
+  name       = "ingress-nginx"
+
+  repository = "https://kubernetes.github.io/ingress-nginx"
+  chart      = "ingress-nginx"
+}
+
+resource "helm_release" "jaeger-operator" {
+  name       = "jaeger-operator"
+
+  repository = "https://jaegertracing.github.io/helm-charts"
+  chart      = "jaeger-operator"
+
+  set {
+    name = "jaeger.create"
+    value = "true"
+  }
+
+  set {
+    name = "metadata.name"
+    value = "simple"
+  }
+}

--- a/modules/container_deployment/main.tf
+++ b/modules/container_deployment/main.tf
@@ -53,28 +53,32 @@ resource "helm_release" "hono" {
     name  = "deviceRegistryExample.mongoDBBasedDeviceRegistry.mongodb.password"
     value = "hono-secret"
   }
+  set {
+    name  = "jaegerAgentConf.REPORTER_GRPC_HOST_PORT"
+    value = "jaeger-operator-jaeger-collector:14250"
+  }
 }
 
 resource "helm_release" "ingress-nginx" {
-  name       = "ingress-nginx"
+  name = "ingress-nginx"
 
   repository = "https://kubernetes.github.io/ingress-nginx"
   chart      = "ingress-nginx"
 }
 
 resource "helm_release" "jaeger-operator" {
-  name       = "jaeger-operator"
+  name = "jaeger-operator"
 
   repository = "https://jaegertracing.github.io/helm-charts"
   chart      = "jaeger-operator"
 
   set {
-    name = "jaeger.create"
+    name  = "jaeger.create"
     value = "true"
   }
 
   set {
-    name = "metadata.name"
+    name  = "metadata.name"
     value = "simple"
   }
 }


### PR DESCRIPTION
Until now Jaeger has run on All-in-one mode "for quick local testing with in-memory storage" launched by Hono Helm chart.
6537335 removes Hono integrated aio Jaeger, launches Jaeger operator and makes it externally available through nginx-ingress

Very basic configuration.

Related to #41 and #44