### PR TITLE
Use PRs branch instead of target branch, and remove check on pushes

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -4,7 +4,6 @@
 name: 'Terraform Validate and plan'
 
 on:
-  push:
   pull_request_target:
     types: [labeled]
 
@@ -32,6 +31,8 @@ jobs:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
     # Install the latest version of Terraform CLI. Enable wrapper for output
     - name: Setup Terraform


### PR DESCRIPTION
Previously PRs used to checkout target branch instead of PRs own branch. This resulted in pipeline to run job on smaddis:master, where desired result would be running on the branch where PR is coming from (eg. msrn:fix-branch).

Also remove check on pushes since it is useless in our workflow.

[Github actions readme](https://github.com/actions/checkout#Checkout-pull-request-HEAD-commit-instead-of-merge-commit)