### PR TITLE
Change testing node count to 2

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "k8s_agent_count" {
 
 # Specify node count for testing purposes
 variable "testing_k8s_agent_count" {
-  default = 1
+  default = 2
 }
 
 # variable "k8s_ssh_public_key" {


### PR DESCRIPTION
Currently when deploying cluster for testing purposes some pods will fail because there is not enough resources.
Changing node count from 1 -> 2 for testing fixes this.