### PR TITLE
Switch to secret to provide Grafana dashboards

### DIFF
--- a/modules/container_deployment/prom_values.yaml
+++ b/modules/container_deployment/prom_values.yaml
@@ -1,6 +1,24 @@
 grafana:
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+      - name: 'Hono'
+        orgId: 1
+        folder: 'Hono'
+        type: file
+        disableDeletion: true
+        editable: false
+        options:
+          path: /etc/secrets/dashboards/
   service:
     type: "LoadBalancer"
+  extraSecretMounts:
+    - name: dashboards-secret-mount
+      secretName: grafana-hono-dashboards
+      defaultMode: 0440
+      mountPath: /etc/secrets/dashboards
+      readOnly: true
 prometheusOperator:
   service:
     type: "LoadBalancer"

--- a/modules/container_deployment/variables.tf
+++ b/modules/container_deployment/variables.tf
@@ -18,7 +18,4 @@ variable "mongodb_rootPassword" {
   default     = "root-secret"
   type        = string
   description = "Optional password for  MongoDB"
-
 }
-
-


### PR DESCRIPTION
Commit 63a0703 switches Kubernetes Configmap to Kubernetes Secret as means to deliver dashboards to Grafana. This means we get rid of the awfully long configmap output in `terraform plan` and `terraform apply`.

Also includes commit fa1b6d7 which is included in pr #75. That should be merged first.