### PR TITLE
NOT WORKING: Jaeger example deployment

### DIFF
--- a/modules/container_deployment/jaeger_values.yaml
+++ b/modules/container_deployment/jaeger_values.yaml
@@ -1,4 +1,8 @@
-jaeger:
-  create: true
-metadata:
-  name: "simple"
+query:
+  service:
+    type: LoadBalancer
+cassandra:
+  persistence:
+      storageClass: "azure-disk-retain"
+schema:
+  activeDeadlineSeconds: 750

--- a/modules/container_deployment/main.tf
+++ b/modules/container_deployment/main.tf
@@ -63,13 +63,15 @@ resource "helm_release" "ingress-nginx" {
   chart      = "ingress-nginx"
   version    = "~> 3.29.0"
 }
-# https://github.com/jaegertracing/helm-charts/tree/72db111cf61e9d85f75b74a8398f2c98da0bc9d3/charts/jaeger-operator
-resource "helm_release" "jaeger-operator" {
-  name = "jaeger-operator"
-
+#https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger
+#pulls bitnami/cassandra chart
+#https://github.com/bitnami/charts/blob/master/bitnami/cassandra/
+resource "helm_release" "jaeger" {
+  name = "jaeger"
   repository = "https://jaegertracing.github.io/helm-charts"
-  chart      = "jaeger-operator"
-  version    = "~> 2.19.1"
+  chart = "jaeger"
+  version = "~> 0.45.1"
+  depends_on = [helm_release.kube-prometheus-stack]
   values = [
     file("${path.module}/jaeger_values.yaml")
   ]


### PR DESCRIPTION
This does not work. Persistent storage does not work applied via Helm chart and sometimes Kube-stack-prometheus, jaeger-collector and jaeger-query break as well. This is somehow PVC/StorageClass related and happened with cassandra deployment trying to allocate volume. 
Things I've tried to make Jaeger persistent storage available:
* Badger
No Helm chart support for Badger. Possible CRD deployment using kubectl or kubernetes-alpha-provider for Terraform is available, see: https://github.com/jaegertracing/jaeger-operator/blob/65490e8fdc240b3bf9a25297dfc1627372134791/examples/with-badger-and-volume.yaml

* Cassandra persistent storageClass: "azure-disk-retain" or different storageclass as well
Does not bind to said storageClass and create PVC like it should ( see https://github.com/bitnami/charts/tree/master/bitnami/cassandra ) 

* Omitted the storageClass configuration so it uses default provisioner
This works and it creates a new PVC, binds to it but its retain policy's not 'retain' so it deletes itself when pod drops. 

Suggestions to continue development:
* kubectl deployment
* elasticsearch database

More info if deciding to go with cassandra deployment:
* schema.activeDeadlineSeconds: 750 
waits for 750seconds before applying cassandra indexing. If it's too low the database deployment isn't ready by the time





Signed-off-by: Sami Wickström <sami.wickstrom@protonmail.com>