### PR TITLE
Add Influx as long-term storage for monitoring data

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,10 +37,18 @@ module "container_deployment" {
 
   #depends_on here or no need? 
   cluster_name = tostring(module.k8s_cluster_azure.k8s_cluster_name)
+
 }
 
 module "datamodule" {
   source = "./modules/datam"
+}
+
+module "influxdb" {
+  providers  = { kubernetes = kubernetes, helm = helm }
+  depends_on = [module.k8s_cluster_azure]
+  source     = "./modules/influxdb"
+  #  count      = var.enable_influxdb_module ? 1 : 0
 }
 
 terraform {

--- a/modules/container_deployment/prom_values.yaml
+++ b/modules/container_deployment/prom_values.yaml
@@ -26,6 +26,12 @@ prometheus:
   service:
     type: "LoadBalancer"
   prometheusSpec:
+    # https://github.com/prometheus-operator/prometheus-operator/blob/3d7e074097abed637c0a8531e285b518da48e7df/Documentation/api.md#remotereadspec
+    remoteRead:
+    - url: "http://influx-influxdb:8086/api/v1/prom/read?db=monitoring_data&u=readuser&p=password"
+    # https://github.com/prometheus-operator/prometheus-operator/blob/3d7e074097abed637c0a8531e285b518da48e7df/Documentation/api.md#remotewritespec
+    remoteWrite:
+    - url: "http://influx-influxdb:8086/api/v1/prom/write?db=monitoring_data&u=writeuser&p=password"
     additionalScrapeConfigs:
       - job_name: hono-pods
         honor_timestamps: true

--- a/modules/influxdb/README.md
+++ b/modules/influxdb/README.md
@@ -1,0 +1,23 @@
+### Upgrading to 2.0.0 see:
+
+https://github.com/bitnami/charts/tree/137854312b3ba5c40f7224b7d752b829e6b1fdcf/bitnami/influxdb#upgrading
+
+# Use Influx Cli
+
+### Get inside pod:
+
+run `$ kubectl get pods` to get pod NAME
+
+run `$ kubectl exec -it <$POD NAME> -- /bin/bash`
+
+ie:
+
+        `$ kubectl exec -it influxdb-85bcf65585-fnmq2  -- /bin/bash`
+
+### Start influx inside pod with
+
+`$ influx -password <$PWD> -username <$USERNAME> -database <$DATABASE NAME>`
+
+ie: 
+
+        `$ influx -password root -username root -database monitoring_data`

--- a/modules/influxdb/influxdb-config.yaml
+++ b/modules/influxdb/influxdb-config.yaml
@@ -1,0 +1,162 @@
+apiVersion: v1
+
+kind: ConfigMap
+metadata:
+  name: influxdb-config
+data:
+  influxdb.conf: |+
+    reporting-disabled: "true"
+    bind-address = "127.0.0.1:8088"
+
+    [meta]
+      dir = "/var/lib/influxdb/meta"
+      retention-autocreate = true
+      logging-enabled = true
+
+    [data]
+      dir = "/var/lib/influxdb/data"
+      index-version = "inmem"
+      wal-dir = "/var/lib/influxdb/wal"
+      wal-fsync-delay = "0s"
+      query-log-enabled = true
+      cache-max-memory-size = 1073741824
+      cache-snapshot-memory-size = 26214400
+      cache-snapshot-write-cold-duration = "10m0s"
+      compact-full-write-cold-duration = "4h0m0s"
+      max-series-per-database = 1000000
+      max-values-per-tag = 100000
+      max-concurrent-compactions = 0
+      max-index-log-file-size = 1048576
+      trace-logging-enabled = false
+      tsm-use-madv-willneed = false
+
+    [coordinator]
+      write-timeout = "10s"
+      max-concurrent-queries = 0
+      query-timeout = "0s"
+      log-queries-after = "0s"
+      max-select-point = 0
+      max-select-series = 0
+      max-select-buckets = 0
+
+    [retention]
+      enabled = true
+      check-interval = "30m0s"
+
+    [shard-precreation]
+      enabled = true
+      check-interval = "10m0s"
+      advance-period = "30m0s"
+
+    [monitor]
+      store-enabled = true
+      store-database = "_internal"
+      store-interval = "10s"
+
+    [subscriber]
+      enabled = true
+      http-timeout = "30s"
+      insecure-skip-verify = false
+      ca-certs = ""
+      write-concurrency = 40
+      write-buffer-size = 1000
+
+    [http]
+      enabled = true
+      bind-address = ":8086"
+      auth-enabled = true
+      log-enabled = true
+      suppress-write-log = false
+      write-tracing = false
+      pprof-enabled = true
+      debug-pprof-enabled = false
+      https-enabled = false
+      https-certificate = "/etc/ssl/influxdb.pem"
+      https-private-key = ""
+      max-row-limit = 0
+      max-connection-limit = 0
+      shared-secret = ""
+      realm = "InfluxDB"
+      unix-socket-enabled = false
+      unix-socket-permissions = "0777"
+      bind-socket = "/var/run/influxdb.sock"
+      max-body-size = 25000000
+      access-log-path = ""
+      max-concurrent-write-limit = 0
+      max-enqueued-write-limit = 0
+      enqueued-write-timeout = 30000000000
+
+    [logging]
+      format = "auto"
+      level = "info"
+      suppress-logo = false
+
+    [ifql]
+      enabled = false
+      log-enabled = true
+      bind-address = ":8082"
+
+    [[graphite]]
+      enabled = false
+      bind-address = ":2003"
+      database = "gatling"
+      retention-policy = ""
+      protocol = "tcp"
+      batch-size = 5000
+      batch-pending = 10
+      batch-timeout = "1s"
+      consistency-level = "one"
+      separator = "."
+      udp-read-buffer = 0
+      templates = [
+        "gatling.*.*.*.*.*.* measurement.test.injector.simulation.request.status.field",
+        "gatling.*.*.*.users.*.* measurement.test.injector.simulation.measurement.request.field"
+      ]
+
+    [[collectd]]
+      enabled = false
+      bind-address = ":25826"
+      database = "collectd"
+      retention-policy = ""
+      batch-size = 5000
+      batch-pending = 10
+      batch-timeout = "10s"
+      read-buffer = 0
+      typesdb = "/usr/share/collectd/types.db"
+      security-level = "none"
+      auth-file = "/etc/collectd/auth_file"
+      parse-multivalue-plugin = "split"
+
+    [[opentsdb]]
+      enabled = false
+      bind-address = ":4242"
+      database = "opentsdb"
+      retention-policy = ""
+      consistency-level = "one"
+      tls-enabled = false
+      certificate = "/etc/ssl/influxdb.pem"
+      batch-size = 1000
+      batch-pending = 5
+      batch-timeout = "1s"
+      log-point-errors = true
+
+    [[udp]]
+      enabled = false
+      bind-address = ":8089"
+      database = "udp"
+      retention-policy = ""
+      batch-size = 5000
+      batch-pending = 10
+      read-buffer = 0
+      batch-timeout = "1s"
+      precision = ""
+
+    [continuous_queries]
+      log-enabled = true
+      enabled = true
+      query-stats-enabled = false
+      run-interval = "1s"
+
+    [tls]
+      min-version = ""
+      max-version = ""

--- a/modules/influxdb/main.tf
+++ b/modules/influxdb/main.tf
@@ -1,0 +1,17 @@
+# https://github.com/bitnami/charts/tree/3f2b19ad2743d28828b5c217b2b682e0db57be75/bitnami/influxdb
+resource "helm_release" "influx" {
+  name       = "influx"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "influxdb"
+  version    = "1.1.8"
+
+  values = [
+    file("${path.module}/values.yaml")
+  ]
+
+  set {
+    name  = "image.tag"
+    value = "1.8.4"
+  }
+
+}

--- a/modules/influxdb/values.yaml
+++ b/modules/influxdb/values.yaml
@@ -1,0 +1,37 @@
+#architecture cannot be "high-availability" unless kubernetes persistent volume claim access mode is "ReadWriteMany"
+architecture: "standalone"
+database: "monitoring_data"
+adminUser:
+  name: "root"
+  pwd: "root"
+user:
+  name: "username"
+  pwd: "password"
+readUser:
+  name: "readuser"
+  pwd: "password"
+writeUser:
+  name: "writeuser"
+  pwd: "password"
+
+
+metrics:
+  enabled: true
+  service:
+    type: "ClusterIP"
+    port: 9122
+
+influxdb:
+  #Only replicaCount 1 is supported with standalone architecture
+  replicaCount: 1
+  service:
+    type: "LoadBalancer"
+    port: 8086
+#  existingConfiguration: name of config map object
+  configuration: |-
+    reporting-disabled = true
+#    bind-address = "127.0.0.1:8086"
+
+persistence:
+  enabled: true
+  existingClaim: "influx-pvc"

--- a/modules/k8s/main.tf
+++ b/modules/k8s/main.tf
@@ -127,3 +127,19 @@ resource "kubernetes_persistent_volume_claim" "example" {
 #    name = "hono"
 #  }
 #}
+
+resource "kubernetes_persistent_volume_claim" "influxdb" {
+  metadata {
+    name = "influx-pvc"
+  }
+  spec {
+    access_modes = ["ReadWriteOnce"]
+    resources {
+      requests = {
+        storage = "8Gi"
+      }
+    }
+    storage_class_name = "azure-disk-retain"
+  }
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,7 @@ variable "tfstate_container_name" {
 ## Azure Kubernetes Service -module related variables
 #
 
+
 variable "k8s_agent_count" {
   default = 3
 }
@@ -56,6 +57,7 @@ variable "k8s_agent_count" {
 variable "testing_k8s_agent_count" {
   default = 2
 }
+
 
 # variable "k8s_ssh_public_key" {
 #     default = "~/.ssh/id_rsa.pub"
@@ -100,6 +102,13 @@ variable "cluster_name" {
 variable "resource_group_name" {
   default = "azure-k8stest"
 }
+
+
+#variable "enable_influxdb_module" {
+#  type        = bool
+#  default     = true
+#  description = "Enable influxdb module"
+#}
 
 ###################################
 ## Container deployment variables##


### PR DESCRIPTION
Adds bitnami helm charts that bootstraps a Influxdb deployment on a Kubernetes cluster using the Helm package manager.
Creates a database monitoring_data and configures Prometheus to remote write and remote read the monitoring_data database. 