### PR TITLE
Add kafka support for Hono tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ override.tf.json
 *kubeconfig
 config.json
 *.jar
+*.jks

--- a/tests/honoscript/receiver.sh
+++ b/tests/honoscript/receiver.sh
@@ -4,13 +4,19 @@ info=./config.json
 
 test -f $info || exit 1
 
-AMQP_NETWORK_IP=$(jq -r .AMQP_NETWORK_IP < $info)
+KAFKA_IP=$(jq -r .KAFKA_IP < $info)
 MY_TENANT=$(jq -r .MY_TENANT < $info)
+KAFKA_TRUSTSTORE_PATH=$(jq -r .KAFKA_TRUSTSTORE_PATH < $info)
 
-java -jar hono-cli-1.6.0-exec.jar \
---hono.client.host=$AMQP_NETWORK_IP \
---hono.client.port=15672 \
---hono.client.username=consumer@HONO \
---hono.client.password=verysecret \
---spring.profiles.active=receiver \
---tenant.id=$MY_TENANT
+java -jar hono-cli-1.9.0-exec.jar \
+--spring.profiles.active=receiver,local,kafka \
+--tenant.id=$MY_TENANT \
+--hono.kafka.commonClientConfig.bootstrap.servers=$KAFKA_IP:9094 \
+--hono.kafka.commonClientConfig.security.protocol=SASL_SSL \
+--hono.kafka.commonClientConfig.sasl.jaas.config="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"hono\" password=\"hono-secret\";" \
+--hono.kafka.commonClientConfig.sasl.mechanism=SCRAM-SHA-512 \
+--hono.kafka.commonClientConfig.ssl.truststore.location=$KAFKA_TRUSTSTORE_PATH \ 
+--hono.kafka.commonClientConfig.ssl.truststore.password=honotrust \
+--hono.kafka.commonClientConfig.ssl.endpoint.identification.algorithm="" 
+#--hono.client.username=consumer@HONO \
+#--hono.client.password=verysecret \


### PR DESCRIPTION
This PR adds support for Hono Helm charts built-in Kafka deployment, and updates hono-cli to version 1.9.0 

Depends on https://github.com/smaddis/smad-deploy-azure/commit/841a2d800ca522082418c488339a0cc86da4f3e0

`setup.sh` now fetches truststore.jks from cluster secrets and external-ip for Kafka service.