### PR TITLE
Disable example data insertion into device registry

### DIFF
--- a/modules/container_deployment/hono_values.yaml
+++ b/modules/container_deployment/hono_values.yaml
@@ -10,6 +10,7 @@ mongodb:
   createInstance: false
 deviceRegistryExample:
   type: "mongodb"
+  addExampleData: false
   mongoDBBasedDeviceRegistry:
     mongodb:
       host: "mongodb"


### PR DESCRIPTION
 * addExampleData indicates if example data is inserted after the device registry is deployed

Signed-off-by: Nindemic <niina.lunden@oulu.fi>