### PR TITLE
Route traffic only through Ambassador API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ $ terraform apply ./modules/tf_state_storage_azure
 ```
 ### No separate storage resource group (default)
 
+2. Remember to edit `main.tf` email variable to a real one for TLS certificate
 2. Deploy main service stack
 
 ```bash
@@ -42,6 +43,16 @@ $ terraform apply ./modules/storage_rg
 ```
 $ terraform apply -var=use_separate_storage_rg=true ./
 ```
+
+## After deployment
+
+After deployment you can use following url for accessing services and adapters {terraform-workspace}.westeurope.cloudapp.azure.com
+
+Hono registry: `{terraform-workspace}.westeurope.cloudapp.azure.com/registry`
+
+Grafana: `{terraform-workspace}.westeurope.cloudapp.azure.com/grafana`
+
+Jaeger: `{terraform-workspace}.westeurope.cloudapp.azure.com/jaeger`
 
 ## License
 [MIT License](./LICENSE)

--- a/ambassador_mappings.yaml
+++ b/ambassador_mappings.yaml
@@ -4,7 +4,17 @@ metadata:
   name: hono-mqtt-adapter
 spec:
   port: 1883
+  #host: ${domain}
   service: hono-adapter-mqtt-vertx:1883
+---
+apiVersion: getambassador.io/v2
+kind:  TCPMapping
+metadata:
+  name: secure-hono-mqtt-adapter
+spec:
+  port: 8883
+  #host: ${domain}
+  service: hono-adapter-mqtt-vertx:8883
 ---
 apiVersion: getambassador.io/v2
 kind:  TCPMapping
@@ -12,6 +22,7 @@ metadata:
   name: hono-device-registry
 spec:
   port: 28080
+  #host: ${domain}
   service: hono-service-device-registry-ext:28080
 ---
 apiVersion: getambassador.io/v2
@@ -28,6 +39,7 @@ metadata:
   name: hono-kafka-external
 spec:
   port: 9092
+  #host: ${domain}
   service: hono-kafka-0-external:9092
 ---
 apiVersion: getambassador.io/v2
@@ -55,9 +67,9 @@ kind:  Mapping
 metadata:
   name: jaeger-operator-jaeger-query
 spec:
-  #port: 80
-  prefix: /jaeger/
-  rewrite: /jaeger/
+  port: 80
+  prefix: /jaeger
+  rewrite: /jaeger
   #host_redirect: true
   host: ${domain}
   service: jaeger-operator-jaeger-query:16686
@@ -68,8 +80,8 @@ metadata:
   name: jaeger-operator-jaeger-query-tcp
 spec:
   port: 16686
-  prefix: /jaeger/
-  host: ${domain}
+  #prefix: /jaeger/
+  #host: ${domain}
   service: jaeger-operator-jaeger-query:16686
 ---
 apiVersion: getambassador.io/v2
@@ -80,6 +92,16 @@ spec:
   prefix: /.well-known/acme-challenge/
   rewrite: ""
   service: acme-challenge-service
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: hono-device-registry-mapping
+spec:
+  #port: 80
+  prefix: /registry
+  host: ${domain}
+  service: hono-service-device-registry-ext:28080
 ---
 apiVersion: getambassador.io/v2
 kind: TLSContext

--- a/modules/container_deployment/ambassador_values.yaml
+++ b/modules/container_deployment/ambassador_values.yaml
@@ -11,6 +11,9 @@ service:
     - name: mqtt-adapter
       port: 1883
       targetPort: 1883
+    - name: mqtt-adaptersec
+      port: 8883
+      targetPort: 8883
     - name: device-registry
       port: 28080
       targetPort: 28080

--- a/modules/container_deployment/jaeger_values.yaml
+++ b/modules/container_deployment/jaeger_values.yaml
@@ -1,12 +1,12 @@
 jaeger:
  create: true
  spec:
-    strategy: production
-    query:
-      serviceType: LoadBalancer
+    strategy: allInOne
+    allInOne:
+      image: jaegertracing/all-in-one:1.13
       options:
-        log-level: debug
-        query:
-          base-path: /jaeger
+          log-level: debug
+          query:
+            base-path: /jaeger
     ingress:
       enabled: false

--- a/tests/honoscript/receiver.sh
+++ b/tests/honoscript/receiver.sh
@@ -4,15 +4,15 @@ info=./config.json
 
 test -f $info || exit 1
 
-KAFKA_IP=$(jq -r .KAFKA_IP < $info)
-#KAFKA_IP=$"workspace-k8stest.westeurope.cloudapp.azure.com"
+DOMAIN_NAME=$(jq -r .DOMAIN_NAME <$info)
+KAFKA_PORT=$(jq -r .KAFKA_PORT < $info)
 MY_TENANT=$(jq -r .MY_TENANT < $info)
 KAFKA_TRUSTSTORE_PATH=$(jq -r .KAFKA_TRUSTSTORE_PATH < $info)
 
 java -jar hono-cli-1.9.0-exec.jar \
 --spring.profiles.active=receiver,local,kafka \
 --tenant.id=$MY_TENANT \
---hono.kafka.commonClientConfig.bootstrap.servers=$KAFKA_IP:9092 \
+--hono.kafka.commonClientConfig.bootstrap.servers=${DOMAIN_NAME}:${KAFKA_PORT} \
 --hono.kafka.commonClientConfig.security.protocol=SASL_SSL \
 --hono.kafka.commonClientConfig.sasl.jaas.config="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"hono\" password=\"hono-secret\";" \
 --hono.kafka.commonClientConfig.sasl.mechanism=SCRAM-SHA-512 \

--- a/tests/honoscript/send.sh
+++ b/tests/honoscript/send.sh
@@ -23,7 +23,7 @@ function mqtt_message() {
     local MESSAGE_TYPE="$1"
     local CONTENT="$2"
 
-    mosquitto_pub -h $MQTT_ADAPTER_IP \
+    mosquitto_pub -h $DOMAIN_NAME -p $MQTT_PORT \
     -u $MY_DEVICE@$MY_TENANT -P $MY_PWD \
     -t $MESSAGE_TYPE -q 1 -m "${CONTENT}"
 
@@ -38,8 +38,9 @@ test -f $info || (echo "missing config.json" && exit 1)
 MY_DEVICE=$(jq -r .MY_DEVICE < $info)
 MY_TENANT=$(jq -r .MY_TENANT < $info)
 MY_PWD=$(jq -r .MY_PWD <$info)
-#HTTP_ADAPTER_IP=$(jq -r .HTTP_ADAPTER_IP <$info)
-MQTT_ADAPTER_IP=$(jq -r .MQTT_ADAPTER_IP <$info)
+DOMAIN_NAME=$(jq -r .DOMAIN_NAME <$info)
+MQTT_PORT=$(jq -r .MQTT_PORT <$info)
+MQTT_SECURE_PORT=$(jq -r .MQTT_SECURE_PORT <$info)
 
 if [[ "$#" = 2 ]]; then
     # Determine content type per message type given as argument


### PR DESCRIPTION
- [x] Add ambassador mappings for all services
- [x]  Fix jaeger base path by using the all-in-one image
- [x] Edit test script to support domain name
- [ ] Disable all load balancers, except Ambassador

With this you can access Jaeger UI from
https://{workspace}.westeurope.cloudapp.azure.com/jaeger/